### PR TITLE
Add range download tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@
 [![Build Status](https://clewolff.visualstudio.com/libcloud-tests/_apis/build/status/c-w.libcloud-tests?branchName=master)](https://clewolff.visualstudio.com/libcloud-tests/_build/latest?definitionId=4&branchName=master)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/python/black)
 
-End-to-end tests for Apache Libcloud
+End-to-end tests for Apache Libcloud.

--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@
 [![Build Status](https://clewolff.visualstudio.com/libcloud-tests/_apis/build/status/c-w.libcloud-tests?branchName=master)](https://clewolff.visualstudio.com/libcloud-tests/_build/latest?definitionId=4&branchName=master)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/python/black)
 
-End-to-end tests for Apache libcloud
+End-to-end tests for Apache Libcloud

--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@
 [![Build Status](https://clewolff.visualstudio.com/libcloud-tests/_apis/build/status/c-w.libcloud-tests?branchName=master)](https://clewolff.visualstudio.com/libcloud-tests/_build/latest?definitionId=4&branchName=master)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/python/black)
 
-End-to-end tests for Apache Libcloud.
+End-to-end tests for Apache Libcloud

--- a/azure-pipelines-install.yaml
+++ b/azure-pipelines-install.yaml
@@ -17,5 +17,5 @@ steps:
   displayName: 'Install requests'
   condition: ne(variables['requests_version'], '')
 
-- script: python -m pip install https://github.com/Kami/libcloud/archive/storage_api_range_download.zip
+- script: python -m pip install https://github.com/$(libcloud_repo)/archive/$(libcloud_version).zip
   displayName: 'Install $(libcloud_version) from $(libcloud_repo)'

--- a/azure-pipelines-install.yaml
+++ b/azure-pipelines-install.yaml
@@ -17,5 +17,5 @@ steps:
   displayName: 'Install requests'
   condition: ne(variables['requests_version'], '')
 
-- script: python -m pip install https://github.com/Kami/archive/storage_api_range_download.zip
+- script: python -m pip install https://github.com/Kami/libcloud/archive/storage_api_range_download.zip
   displayName: 'Install $(libcloud_version) from $(libcloud_repo)'

--- a/azure-pipelines-install.yaml
+++ b/azure-pipelines-install.yaml
@@ -17,5 +17,5 @@ steps:
   displayName: 'Install requests'
   condition: ne(variables['requests_version'], '')
 
-- script: python -m pip install https://github.com/$(libcloud_repo)/archive/$(libcloud_version).zip
+- script: python -m pip install https://github.com/Kami/archive/storage_api_range_download.zip
   displayName: 'Install $(libcloud_version) from $(libcloud_repo)'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-git+https://github.com/Kami/libcloud.git@storage_api_range_download#egg=libcloud
+apache-libcloud
 black==19.10b0
 flake8==3.7.9
 invoke

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,3 @@
-apache-libcloud
 git+https://github.com/Kami/libcloud.git@storage_api_range_download#egg=libcloud
 black
 flake8

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 apache-libcloud
+git+https://github.com/Kami/libcloud.git@storage_api_range_download#egg=libcloud
 black
 flake8
 invoke

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,5 +3,5 @@ git+https://github.com/Kami/libcloud.git@storage_api_range_download#egg=libcloud
 black
 flake8
 invoke
-isort
-pylint
+isort==4.3.21
+pylint==2.4.4

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 git+https://github.com/Kami/libcloud.git@storage_api_range_download#egg=libcloud
-black
-flake8
+black==19.10b0
+flake8==3.7.9
 invoke
 isort==4.3.21
 pylint==2.4.4

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -172,7 +172,9 @@ class SmokeStorageTest(unittest.TestCase):
 
             # 2. download_object_range_as_stream
             downloaded_content = _read_stream(
-                self.driver.download_object_as_stream(obj)
+                self.driver.download_object_range_as_stream(
+                    obj, start_bytes=start_bytes, end_bytes=end_bytes
+                )
             )
             self.assertEqual(downloaded_content, expected_content)
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -10,7 +10,6 @@ import time
 import unittest
 
 import requests
-
 from libcloud.storage import providers, types
 
 MB = 1024 * 1024

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -132,10 +132,12 @@ class SmokeStorageTest(unittest.TestCase):
         self.assertEqual(obj.size, len(content))
 
         values = [
-            {"start_bytes": 0, "end_bytes": 0},
+            {"start_bytes": 0, "end_bytes": 1},
             {"start_bytes": 1, "end_bytes": 5},
             {"start_bytes": 5, "end_bytes": None},
             {"start_bytes": 5, "end_bytes": len(content)},
+            {"start_bytes": 0, "end_bytes": None},
+            {"start_bytes": 0, "end_bytes": len(content)},
         ]
 
         for value in values:

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -10,6 +10,7 @@ import time
 import unittest
 
 import requests
+
 from libcloud.storage import providers, types
 
 MB = 1024 * 1024
@@ -132,22 +133,10 @@ class SmokeStorageTest(unittest.TestCase):
         self.assertEqual(obj.size, len(content))
 
         values = [
-            {
-                "start_bytes": 0,
-                "end_bytes": 0
-            },
-            {
-                "start_bytes": 1,
-                "end_bytes": 5
-            },
-            {
-                "start_bytes": 5,
-                "end_bytes": None
-            },
-            {
-                "start_bytes": 5,
-                "end_bytes": len(content)
-            }
+            {"start_bytes": 0, "end_bytes": 0},
+            {"start_bytes": 1, "end_bytes": 5},
+            {"start_bytes": 5, "end_bytes": None},
+            {"start_bytes": 5, "end_bytes": len(content)},
         ]
 
         for value in values:
@@ -156,24 +145,29 @@ class SmokeStorageTest(unittest.TestCase):
             end_bytes = value["end_bytes"]
             outfile = self._create_tempfile()
 
-            result = self.driver.download_object_range(obj, outfile,
-                                              start_bytes=start_bytes,
-                                              end_bytes=end_bytes,
-                                              overwrite_existing=True)
+            result = self.driver.download_object_range(
+                obj,
+                outfile,
+                start_bytes=start_bytes,
+                end_bytes=end_bytes,
+                overwrite_existing=True,
+            )
             self.assertTrue(result)
 
             with open(outfile, "rb") as fobj:
                 downloaded_content = fobj.read()
 
             if end_bytes is not None:
-                expected_content = content[start_bytes:end_bytes + 1]
+                expected_content = content[start_bytes : end_bytes + 1]
             else:
                 expected_content = content[start_bytes]
 
             self.assertEqual(downloaded_content, expected_content)
 
             # 2. download_object_range_as_stream
-            downloaded_content = _read_stream(self.driver.download_object_as_stream(obj))
+            downloaded_content = _read_stream(
+                self.driver.download_object_as_stream(obj)
+            )
             self.assertEqual(downloaded_content, expected_content)
 
     @unittest.skipUnless(os.getenv("LARGE_FILE_SIZE_MB"), "config not set")

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -158,7 +158,7 @@ class SmokeStorageTest(unittest.TestCase):
                 downloaded_content = fobj.read()
 
             if end_bytes is not None:
-                expected_content = content[start_bytes : end_bytes + 1]
+                expected_content = content[start_bytes : end_bytes]
             else:
                 expected_content = content[start_bytes]
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -132,15 +132,15 @@ class SmokeStorageTest(unittest.TestCase):
         self.assertEqual(obj.size, len(content))
 
         values = [
-            {"start_bytes": 0, "end_bytes": 1, "expected_content": "0"},
-            {"start_bytes": 1, "end_bytes": 5, "expected_content": "1234"},
-            {"start_bytes": 5, "end_bytes": None, "expected_content": "56789"},
-            {"start_bytes": 5, "end_bytes": len(content), "expected_content": "56789"},
-            {"start_bytes": 0, "end_bytes": None, "expected_content": "0123456789"},
+            {"start_bytes": 0, "end_bytes": 1, "expected_content": b"0"},
+            {"start_bytes": 1, "end_bytes": 5, "expected_content": b"1234"},
+            {"start_bytes": 5, "end_bytes": None, "expected_content": b"56789"},
+            {"start_bytes": 5, "end_bytes": len(content), "expected_content": b"56789"},
+            {"start_bytes": 0, "end_bytes": None, "expected_content": b"0123456789"},
             {
                 "start_bytes": 0,
                 "end_bytes": len(content),
-                "expected_content": "0123456789",
+                "expected_content": b"0123456789",
             },
         ]
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -125,6 +125,8 @@ class SmokeStorageTest(unittest.TestCase):
         infile = self._create_tempfile(content=content)
         obj = self.driver.upload_object(infile, container, blob_name)
         self.assertEqual(obj.name, blob_name)
+        self.assertEqual(obj.size, len(content))
+
         obj = self.driver.get_object(container.name, blob_name)
         self.assertEqual(obj.name, blob_name)
         self.assertEqual(obj.size, len(content))

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -158,7 +158,7 @@ class SmokeStorageTest(unittest.TestCase):
                 downloaded_content = fobj.read()
 
             if end_bytes is not None:
-                expected_content = content[start_bytes : end_bytes]
+                expected_content = content[start_bytes:end_bytes]
             else:
                 expected_content = content[start_bytes]
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -159,9 +159,14 @@ class SmokeStorageTest(unittest.TestCase):
             if end_bytes is not None:
                 expected_content = content[start_bytes:end_bytes]
             else:
-                expected_content = content[start_bytes]
+                expected_content = content[start_bytes:]
 
-            self.assertEqual(downloaded_content, expected_content)
+            msg = 'Expected "%s", got "%s" for values: %s' % (
+                expected_content,
+                downloaded_content,
+                str(value),
+            )
+            self.assertEqual(downloaded_content, expected_content, msg)
 
             # 2. download_object_range_as_stream
             downloaded_content = _read_stream(

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -117,6 +117,63 @@ class SmokeStorageTest(unittest.TestCase):
 
         self._test_objects(do_upload, do_download, size)
 
+    def test_objects_range_downloads(self):
+        blob_name = "testblob-range"
+        content = b"0123456789"
+        container = self.driver.create_container(_random_container_name())
+
+        infile = self._create_tempfile(content=content)
+        obj = self.driver.upload_object(infile, container, blob_name)
+        self.assertEqual(obj.name, blob_name)
+        obj = self.driver.get_object(container.name, blob_name)
+        self.assertEqual(obj.name, blob_name)
+        self.assertEqual(obj.size, len(content))
+
+        values = [
+            {
+                "start_bytes": 0,
+                "end_bytes": 0
+            },
+            {
+                "start_bytes": 1,
+                "end_bytes": 5
+            },
+            {
+                "start_bytes": 5,
+                "end_bytes": None
+            },
+            {
+                "start_bytes": 5,
+                "end_bytes": len(content)
+            }
+        ]
+
+        for value in values:
+            # 1. download_object_range
+            start_bytes = value["start_bytes"]
+            end_bytes = value["end_bytes"]
+            outfile = self._create_tempfile()
+
+            result = self.driver.download_object_range(obj, outfile,
+                                              start_bytes=start_bytes,
+                                              end_bytes=end_bytes,
+                                              overwrite_existing=True)
+            self.assertTrue(result)
+
+            with open(outfile, "rb") as fobj:
+                downloaded_content = fobj.read()
+
+            if end_bytes is not None:
+                expected_content = content[start_bytes:end_bytes]
+            else:
+                expected_content = content[start_bytes]
+
+            self.assertEqual(downloaded_content, expected_content)
+
+            # 2. download_object_range_as_stream
+            downloaded_content = _read_stream(self.driver.download_object_as_stream(obj))
+            self.assertEqual(downloaded_content, expected_content)
+
     @unittest.skipUnless(os.getenv("LARGE_FILE_SIZE_MB"), "config not set")
     def test_objects_large(self):
         size = int(float(os.environ["LARGE_FILE_SIZE_MB"]) * MB)

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -166,7 +166,7 @@ class SmokeStorageTest(unittest.TestCase):
                 downloaded_content = fobj.read()
 
             if end_bytes is not None:
-                expected_content = content[start_bytes:end_bytes]
+                expected_content = content[start_bytes:end_bytes + 1]
             else:
                 expected_content = content[start_bytes]
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -132,12 +132,16 @@ class SmokeStorageTest(unittest.TestCase):
         self.assertEqual(obj.size, len(content))
 
         values = [
-            {"start_bytes": 0, "end_bytes": 1},
-            {"start_bytes": 1, "end_bytes": 5},
-            {"start_bytes": 5, "end_bytes": None},
-            {"start_bytes": 5, "end_bytes": len(content)},
-            {"start_bytes": 0, "end_bytes": None},
-            {"start_bytes": 0, "end_bytes": len(content)},
+            {"start_bytes": 0, "end_bytes": 1, "expected_content": "0"},
+            {"start_bytes": 1, "end_bytes": 5, "expected_content": "1234"},
+            {"start_bytes": 5, "end_bytes": None, "expected_content": "56789"},
+            {"start_bytes": 5, "end_bytes": len(content), "expected_content": "56789"},
+            {"start_bytes": 0, "end_bytes": None, "expected_content": "0123456789"},
+            {
+                "start_bytes": 0,
+                "end_bytes": len(content),
+                "expected_content": "0123456789",
+            },
         ]
 
         for value in values:
@@ -169,6 +173,7 @@ class SmokeStorageTest(unittest.TestCase):
                 str(value),
             )
             self.assertEqual(downloaded_content, expected_content, msg)
+            self.assertEqual(downloaded_content, value["expected_content"], msg)
 
             # 2. download_object_range_as_stream
             downloaded_content = _read_stream(


### PR DESCRIPTION
This pull request adds tests for range downloads functionality implemented in https://github.com/apache/libcloud/pull/1431.

I haven't it ran locally yet so I hope the CI is configured to also trigger of forked PRs so I can verify it's working correctly.